### PR TITLE
refactor host reads to use vm.fs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { type Dirent, constants as fsConstants } from "node:fs";
-import { lstat, mkdir, open, readdir, readFile, realpath, writeFile } from "node:fs/promises";
-import { basename, extname, isAbsolute, join, relative } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { extname, join, posix as posixPath } from "node:path";
 import { ensureGuestAssets, hasGuestAssets } from "@earendil-works/gondolin";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
@@ -28,6 +27,7 @@ import {
 } from "./src/config.js";
 
 import type { ResolvedConversation } from "./src/core/config-types.js";
+import type { OutboundAttachment } from "./src/core/runtime-types.js";
 import { ConversationSandbox, GONDOLIN_SHARED, GONDOLIN_WORKSPACE } from "./src/gondolin.js";
 import { connectLive } from "./src/live/index.js";
 import type { LiveConnection } from "./src/live/types.js";
@@ -124,11 +124,6 @@ interface ChatPromptSkill {
 	filePath: string;
 }
 
-function isInsideHostPath(root: string, value: string): boolean {
-	const rel = relative(root, value);
-	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
-}
-
 function escapeXml(value: string): string {
 	return value
 		.replace(/&/g, "&amp;")
@@ -136,24 +131,6 @@ function escapeXml(value: string): string {
 		.replace(/>/g, "&gt;")
 		.replace(/"/g, "&quot;")
 		.replace(/'/g, "&apos;");
-}
-
-async function safeReadMountedText(root: string, filePath: string): Promise<string> {
-	try {
-		const realRoot = await realpath(root);
-		const resolvedPath = await realpath(filePath);
-		if (!isInsideHostPath(realRoot, resolvedPath)) return "";
-		const handle = await open(resolvedPath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
-		try {
-			const info = await handle.stat();
-			if (!info.isFile()) return "";
-			return await handle.readFile("utf8");
-		} finally {
-			await handle.close();
-		}
-	} catch {
-		return "";
-	}
 }
 
 function parseSkillFrontmatter(content: string): { name?: string; description?: string; disabled?: boolean } {
@@ -175,40 +152,38 @@ function parseSkillFrontmatter(content: string): { name?: string; description?: 
 	return frontmatter;
 }
 
-async function loadSafeChatSkills(root: string): Promise<ChatPromptSkill[]> {
-	const skillsRoot = join(root, "skills");
+async function loadSafeChatSkills(sandbox: ConversationSandbox, root: string): Promise<ChatPromptSkill[]> {
+	const skillsRoot = posixPath.join(root, "skills");
 	const skills: ChatPromptSkill[] = [];
 	async function addSkill(filePath: string, defaultName: string): Promise<void> {
-		const content = await safeReadMountedText(root, filePath);
+		const content = await sandbox.readMountedText(filePath);
 		const frontmatter = parseSkillFrontmatter(content);
 		if (!frontmatter.description?.trim() || frontmatter.disabled) return;
 		skills.push({ name: frontmatter.name || defaultName, description: frontmatter.description, filePath });
 	}
 	async function walkSkills(dir: string, depth: number): Promise<void> {
 		if (depth > 8) return;
-		let entries: Dirent<string>[];
+		let names: string[];
 		try {
-			entries = await readdir(dir, { withFileTypes: true });
+			names = await sandbox.listMountedDirectory(dir);
 		} catch {
 			return;
 		}
-		for (const entry of entries) {
-			if (entry.name.startsWith(".") || entry.name === "node_modules" || entry.isSymbolicLink()) continue;
-			const fullPath = join(dir, entry.name);
-			if (entry.isFile() && extname(entry.name).toLowerCase() === ".md") {
-				await addSkill(fullPath, basename(entry.name, ".md"));
+		for (const name of names) {
+			if (name.startsWith(".") || name === "node_modules") continue;
+			const fullPath = posixPath.join(dir, name);
+			const entryStat = await sandbox.stat(fullPath).catch(() => undefined);
+			if (!entryStat) continue;
+			if (entryStat.isFile()) {
+				if (extname(name).toLowerCase() === ".md") await addSkill(fullPath, posixPath.basename(name, ".md"));
 				continue;
 			}
-			if (!entry.isDirectory()) continue;
-			const skillMd = join(fullPath, "SKILL.md");
-			try {
-				const info = await lstat(skillMd);
-				if (info.isFile()) {
-					await addSkill(skillMd, entry.name);
-					continue;
-				}
-			} catch {
-				// Not a skill root; recurse below.
+			if (!entryStat.isDirectory()) continue;
+			const skillMd = posixPath.join(fullPath, "SKILL.md");
+			const skillStat = await sandbox.stat(skillMd).catch(() => undefined);
+			if (skillStat?.isFile()) {
+				await addSkill(skillMd, name);
+				continue;
 			}
 			await walkSkills(fullPath, depth + 1);
 		}
@@ -442,7 +417,7 @@ export default function (pi: ExtensionAPI) {
 	let configLoadedAtLeastOnce = false;
 	let typingInterval: ReturnType<typeof setInterval> | undefined;
 	let workerStatusInterval: ReturnType<typeof setInterval> | undefined;
-	let queuedOutboundAttachments: string[] = [];
+	let queuedOutboundAttachments: OutboundAttachment[] = [];
 	let pendingChatDispatch = false;
 	let pendingControlAction: (() => Promise<void>) | undefined;
 	let activeTriggerMessageId: string | undefined;
@@ -526,54 +501,30 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	async function buildMemoryPromptSuffix(): Promise<string> {
-		if (!runtime) return "";
+		if (!runtime || !sandbox) return "";
 		const sections: string[] = [];
-		const accountMemory = await safeReadMountedText(
-			runtime.conversation.sharedDir,
-			runtime.conversation.accountMemoryPath,
-		);
-		const channelMemory = await safeReadMountedText(
-			runtime.conversation.workspaceDir,
-			runtime.conversation.channelMemoryPath,
-		);
+		const accountMemory = await sandbox.readMountedText(`${GONDOLIN_SHARED}/memory.md`);
+		const channelMemory = await sandbox.readMountedText(`${GONDOLIN_WORKSPACE}/memory.md`);
 		if (accountMemory.trim()) sections.push(`Account memory (/shared/memory.md):\n${accountMemory.trim()}`);
 		if (channelMemory.trim()) sections.push(`Channel memory (/workspace/memory.md):\n${channelMemory.trim()}`);
 		if (sections.length === 0) return "";
 		return `\n\nPersistent memory:\n${sections.join("\n\n")}`;
 	}
 
-	function hostToGuestPath(hostPath: string): string {
-		if (!runtime) return hostPath;
-		const { workspaceDir, sharedDir } = runtime.conversation;
-		if (hostPath === workspaceDir || hostPath.startsWith(`${workspaceDir}/`)) {
-			const suffix = hostPath.slice(workspaceDir.length).replace(/^\//, "");
-			return suffix ? `/workspace/${suffix}` : "/workspace";
-		}
-		if (hostPath === sharedDir || hostPath.startsWith(`${sharedDir}/`)) {
-			const suffix = hostPath.slice(sharedDir.length).replace(/^\//, "");
-			return suffix ? `/shared/${suffix}` : "/shared";
-		}
-		return hostPath;
-	}
-
 	async function buildSkillsPromptSuffix(): Promise<string> {
-		if (!runtime) return "";
-		const sharedSkills = await loadSafeChatSkills(runtime.conversation.sharedDir);
-		const channelSkills = await loadSafeChatSkills(runtime.conversation.workspaceDir);
+		if (!runtime || !sandbox) return "";
+		const sharedSkills = await loadSafeChatSkills(sandbox, GONDOLIN_SHARED);
+		const channelSkills = await loadSafeChatSkills(sandbox, GONDOLIN_WORKSPACE);
 		const skillMap = new Map<string, ChatPromptSkill>();
 		for (const skill of sharedSkills) skillMap.set(skill.name, skill);
 		for (const skill of channelSkills) skillMap.set(skill.name, skill);
-		const allSkills = [...skillMap.values()].map((skill) => ({ ...skill, filePath: hostToGuestPath(skill.filePath) }));
-		const formatted = formatChatSkillsForPrompt(allSkills);
+		const formatted = formatChatSkillsForPrompt([...skillMap.values()]);
 		return formatted ? `\n\nAvailable skills:\n${formatted}` : "";
 	}
 
 	async function buildSystemMdSuffix(): Promise<string> {
-		if (!runtime) return "";
-		const systemMd = await safeReadMountedText(
-			runtime.conversation.workspaceDir,
-			join(runtime.conversation.workspaceDir, "SYSTEM.md"),
-		);
+		if (!runtime || !sandbox) return "";
+		const systemMd = await sandbox.readMountedText(`${GONDOLIN_WORKSPACE}/SYSTEM.md`);
 		if (!systemMd.trim()) return "";
 		return `\n\nSystem configuration log (/workspace/SYSTEM.md):\n${systemMd.trim()}`;
 	}
@@ -800,19 +751,13 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	async function showChatContextMessage(): Promise<void> {
-		if (!runtime) return;
+		if (!runtime || !sandbox) return;
 		const channelName = runtime.conversation.channel.name ?? runtime.conversation.channelKey;
 		const mode = runtime.conversation.channel.dm ? "dm" : "mention";
 		const service = runtime.conversation.service;
 		const systemPromptAdditions = buildChatSystemPromptSuffix(service, mode, channelName).trim();
-		const accountMemory = await safeReadMountedText(
-			runtime.conversation.sharedDir,
-			runtime.conversation.accountMemoryPath,
-		);
-		const channelMemory = await safeReadMountedText(
-			runtime.conversation.workspaceDir,
-			runtime.conversation.channelMemoryPath,
-		);
+		const accountMemory = await sandbox.readMountedText(`${GONDOLIN_SHARED}/memory.md`);
+		const channelMemory = await sandbox.readMountedText(`${GONDOLIN_WORKSPACE}/memory.md`);
 		const skillsSuffix = await buildSkillsPromptSuffix();
 		const sections = [`Connected to ${service} ${mode} ${channelName}.`, "", "System prompt:", systemPromptAdditions];
 		if (accountMemory.trim()) sections.push("", "Account memory (/shared/memory.md):", accountMemory.trim());
@@ -1024,7 +969,7 @@ export default function (pi: ExtensionAPI) {
 			signal?.throwIfAborted?.();
 			for (const path of params.paths) {
 				signal?.throwIfAborted?.();
-				queuedOutboundAttachments.push(await sandbox.stageAttachment(path));
+				queuedOutboundAttachments.push(await sandbox.readAttachment(path));
 			}
 			return {
 				content: [{ type: "text", text: `Queued ${params.paths.length} attachment(s).` }],
@@ -1434,13 +1379,13 @@ export default function (pi: ExtensionAPI) {
 		}
 		stopTypingLoop();
 		let remoteMessageId: string | undefined;
-		const attachmentPaths = [...queuedOutboundAttachments];
+		const attachments = [...queuedOutboundAttachments];
 		queuedOutboundAttachments = [];
-		const finalText = summary.text || (attachmentPaths.length > 0 ? "Attached requested file(s)." : "");
+		const finalText = summary.text || (attachments.length > 0 ? "Attached requested file(s)." : "");
 		if (liveConnection && finalText) {
 			try {
 				remoteMessageId = await Promise.race([
-					liveConnection.send(finalText, attachmentPaths, ctx.signal, activeTriggerMessageId),
+					liveConnection.send(finalText, attachments, ctx.signal, activeTriggerMessageId),
 					new Promise<string>((_, reject) => setTimeout(() => reject(new Error("send timed out")), 120000)),
 					waitForAbort(ctx.signal),
 				]);
@@ -1460,7 +1405,11 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 		chatTurnInFlight = false;
-		await runtime.completeActiveJob(finalText, remoteMessageId, attachmentPaths);
+		await runtime.completeActiveJob(
+			finalText,
+			remoteMessageId,
+			attachments.map((attachment) => attachment.path),
+		);
 		updateStatus(ctx);
 		await tryDispatch(ctx);
 	});

--- a/src/core/runtime-types.ts
+++ b/src/core/runtime-types.ts
@@ -10,6 +10,13 @@ export interface AttachmentInput {
 	remoteUrl?: string;
 }
 
+export interface OutboundAttachment {
+	path: string;
+	name: string;
+	data: Uint8Array;
+	mimeType?: string;
+}
+
 export interface StoredAttachment {
 	kind: AttachmentKind;
 	name: string;

--- a/src/gondolin.ts
+++ b/src/gondolin.ts
@@ -1,11 +1,11 @@
-import { randomUUID } from "node:crypto";
-import { constants as fsConstants, realpathSync } from "node:fs";
-import { access, mkdir, open, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { access, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { createHttpHooks, RealFSProvider, type SecretDefinition, VM } from "@earendil-works/gondolin";
 
 import type { ResolvedConversation } from "./core/config-types.js";
+import type { OutboundAttachment } from "./core/runtime-types.js";
 import { ensureConversationDirs } from "./log.js";
 
 export const GONDOLIN_WORKSPACE = "/workspace";
@@ -23,6 +23,26 @@ function isInside(root: string, value: string): boolean {
 function guestMountRoot(guestPath: string): typeof GONDOLIN_WORKSPACE | typeof GONDOLIN_SHARED | undefined {
 	if (guestPath === GONDOLIN_WORKSPACE || guestPath.startsWith(`${GONDOLIN_WORKSPACE}/`)) return GONDOLIN_WORKSPACE;
 	if (guestPath === GONDOLIN_SHARED || guestPath.startsWith(`${GONDOLIN_SHARED}/`)) return GONDOLIN_SHARED;
+	return undefined;
+}
+
+function guessMimeType(fileName: string): string | undefined {
+	const ext = path.posix.extname(fileName).toLowerCase();
+	if (ext === ".png") return "image/png";
+	if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+	if (ext === ".gif") return "image/gif";
+	if (ext === ".webp") return "image/webp";
+	if (ext === ".mp3") return "audio/mpeg";
+	if (ext === ".wav") return "audio/wav";
+	if (ext === ".ogg") return "audio/ogg";
+	if (ext === ".m4a") return "audio/mp4";
+	if (ext === ".mp4") return "video/mp4";
+	if (ext === ".mov") return "video/quicktime";
+	if (ext === ".webm") return "video/webm";
+	if (ext === ".pdf") return "application/pdf";
+	if (ext === ".json") return "application/json";
+	if (ext === ".md") return "text/markdown";
+	if (ext === ".txt" || ext === ".log") return "text/plain";
 	return undefined;
 }
 
@@ -104,34 +124,55 @@ export class ConversationSandbox {
 		if (vm) await vm.close();
 	}
 
-	private resolveGuestPath(inputPath: string): string {
+	private resolveAnyGuestPath(inputPath: string): string {
 		const trimmed = inputPath.trim();
 		if (!trimmed) throw new Error("Path must not be empty");
 		const base = trimmed.startsWith("/") ? "/" : GONDOLIN_WORKSPACE;
-		const guestPath = path.posix.resolve(base, trimmed);
+		return path.posix.resolve(base, trimmed);
+	}
+
+	private resolveGuestPath(inputPath: string): string {
+		const guestPath = this.resolveAnyGuestPath(inputPath);
 		if (!guestMountRoot(guestPath)) throw new Error(`Path is outside mounted storage: ${inputPath}`);
 		return guestPath;
 	}
 
-	async stageAttachment(inputPath: string): Promise<string> {
-		const sourcePath = this.guestToHostPath(inputPath);
-		const handle = await open(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+	async readAttachment(inputPath: string): Promise<OutboundAttachment> {
+		const vm = await this.start();
+		const guestPath = this.resolveAnyGuestPath(inputPath);
+		const fileStats = await vm.fs.stat(guestPath);
+		if (!fileStats.isFile()) throw new Error(`Not a file: ${inputPath}`);
+		const name = path.posix.basename(guestPath).replace(/[^a-zA-Z0-9._-]+/g, "_") || "attachment";
+		return {
+			path: guestPath,
+			name,
+			data: new Uint8Array(await vm.fs.readFile(guestPath)),
+			mimeType: guessMimeType(guestPath),
+		};
+	}
+
+	async readMountedText(inputPath: string): Promise<string> {
 		try {
-			const fileStats = await handle.stat();
-			if (!fileStats.isFile()) throw new Error(`Not a file: ${inputPath}`);
-			const stagingDir = path.join(this.conversation.gondolinDir, "outgoing");
-			await mkdir(stagingDir, { recursive: true });
-			const safeName = path.basename(sourcePath).replace(/[^a-zA-Z0-9._-]+/g, "_") || "attachment";
-			const stagedPath = path.join(stagingDir, `${Date.now()}-${randomUUID()}-${safeName}`);
-			await writeFile(stagedPath, await handle.readFile(), { flag: "wx" });
-			return stagedPath;
-		} finally {
-			await handle.close();
+			const vm = await this.start();
+			const guestPath = this.resolveGuestPath(inputPath);
+			const fileStats = await vm.fs.stat(guestPath);
+			if (!fileStats.isFile()) return "";
+			return await vm.fs.readFile(guestPath, { encoding: "utf8" });
+		} catch {
+			return "";
 		}
 	}
 
-	resolveToolPath(inputPath: string): string {
-		return this.resolveGuestPath(inputPath);
+	async listMountedDirectory(inputPath: string): Promise<string[]> {
+		const vm = await this.start();
+		const guestPath = this.resolveGuestPath(inputPath);
+		return vm.fs.listDir(guestPath);
+	}
+
+	async stat(inputPath: string) {
+		const vm = await this.start();
+		const guestPath = this.resolveGuestPath(inputPath);
+		return vm.fs.stat(guestPath);
 	}
 
 	guestToHostPath(inputPath: string): string {

--- a/src/gondolin.ts
+++ b/src/gondolin.ts
@@ -124,22 +124,18 @@ export class ConversationSandbox {
 		if (vm) await vm.close();
 	}
 
-	private resolveAnyGuestPath(inputPath: string): string {
+	private resolveGuestPath(inputPath: string): string {
 		const trimmed = inputPath.trim();
 		if (!trimmed) throw new Error("Path must not be empty");
 		const base = trimmed.startsWith("/") ? "/" : GONDOLIN_WORKSPACE;
-		return path.posix.resolve(base, trimmed);
-	}
-
-	private resolveGuestPath(inputPath: string): string {
-		const guestPath = this.resolveAnyGuestPath(inputPath);
+		const guestPath = path.posix.resolve(base, trimmed);
 		if (!guestMountRoot(guestPath)) throw new Error(`Path is outside mounted storage: ${inputPath}`);
 		return guestPath;
 	}
 
 	async readAttachment(inputPath: string): Promise<OutboundAttachment> {
 		const vm = await this.start();
-		const guestPath = this.resolveAnyGuestPath(inputPath);
+		const guestPath = this.resolveGuestPath(inputPath);
 		const fileStats = await vm.fs.stat(guestPath);
 		if (!fileStats.isFile()) throw new Error(`Not a file: ${inputPath}`);
 		const name = path.posix.basename(guestPath).replace(/[^a-zA-Z0-9._-]+/g, "_") || "attachment";

--- a/src/live/common.ts
+++ b/src/live/common.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import type { ResolvedConversation } from "../core/config-types.js";
 import type { AttachmentInput } from "../core/runtime-types.js";
@@ -39,34 +39,6 @@ export function guessAttachmentKind(fileName: string, mimeType?: string): "image
 	if ([".mp3", ".wav", ".ogg", ".m4a"].includes(ext)) return "audio";
 	if ([".mp4", ".mov", ".webm"].includes(ext)) return "video";
 	return "file";
-}
-
-export function guessMimeType(fileName: string): string | undefined {
-	const ext = extname(fileName).toLowerCase();
-	if (ext === ".png") return "image/png";
-	if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
-	if (ext === ".gif") return "image/gif";
-	if (ext === ".webp") return "image/webp";
-	if (ext === ".mp3") return "audio/mpeg";
-	if (ext === ".wav") return "audio/wav";
-	if (ext === ".ogg") return "audio/ogg";
-	if (ext === ".m4a") return "audio/mp4";
-	if (ext === ".mp4") return "video/mp4";
-	if (ext === ".mov") return "video/quicktime";
-	if (ext === ".webm") return "video/webm";
-	if (ext === ".pdf") return "application/pdf";
-	if (ext === ".json") return "application/json";
-	if (ext === ".md") return "text/markdown";
-	if (ext === ".txt" || ext === ".log") return "text/plain";
-	return undefined;
-}
-
-export async function readLocalAttachment(
-	path: string,
-): Promise<{ name: string; data: Uint8Array; mimeType?: string }> {
-	const fileStats = await lstat(path);
-	if (!fileStats.isFile()) throw new Error(`Attachment is not a regular file: ${path}`);
-	return { name: basename(path), data: new Uint8Array(await readFile(path)), mimeType: guessMimeType(path) };
 }
 
 export async function fetchBinary(url: string, headers?: HeadersInit): Promise<Uint8Array> {

--- a/src/live/discord.ts
+++ b/src/live/discord.ts
@@ -5,11 +5,11 @@ import { once } from "node:events";
 import { Client, Events, GatewayIntentBits, type Message, Partials } from "discord.js";
 
 import type { DiscordAccountConfig, ResolvedConversation } from "../core/config-types.js";
-import type { InboundMessageInput } from "../core/runtime-types.js";
+import type { InboundMessageInput, OutboundAttachment } from "../core/runtime-types.js";
 import { chunkText } from "../render/chunking.js";
 import { formatMarkdownForService, maxMessageLength } from "../render/format.js";
 import { StreamingPreview } from "../render/streaming.js";
-import { readLocalAttachment, storeDownloadedAttachment, textMentionsBot } from "./common.js";
+import { storeDownloadedAttachment, textMentionsBot } from "./common.js";
 import type { LiveConnection, LiveConnectionHandlers } from "./types.js";
 
 async function withReadyClient(token: string): Promise<Client<true>> {
@@ -120,7 +120,7 @@ async function sendDiscordMessage(
 	botToken: string,
 	channelId: string,
 	content: string,
-	attachmentPaths: string[] = [],
+	attachments: OutboundAttachment[] = [],
 	signal?: AbortSignal,
 	replyToMessageId?: string,
 ): Promise<string> {
@@ -131,11 +131,10 @@ async function sendDiscordMessage(
 	for (let i = 0; i < chunks.length; i++) {
 		const payload: Record<string, unknown> = { content: chunks[i] };
 		if (i === 0 && replyToMessageId) payload.message_reference = { message_id: replyToMessageId };
-		if (i === chunks.length - 1 && attachmentPaths.length > 0) {
+		if (i === chunks.length - 1 && attachments.length > 0) {
 			const form = new FormData();
 			form.set("payload_json", JSON.stringify(payload));
-			for (const [index, path] of attachmentPaths.entries()) {
-				const file = await readLocalAttachment(path);
+			for (const [index, file] of attachments.entries()) {
 				form.set(`files[${index}]`, new Blob([Buffer.from(file.data)], { type: file.mimeType }), file.name);
 			}
 			const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
@@ -241,8 +240,8 @@ export async function connectDiscordLive(
 		sendImmediate: async (text, replyToMessageId) => {
 			return sendDiscordMessage(account.botToken, conversation.channel.id, text, [], undefined, replyToMessageId);
 		},
-		send: async (text, attachmentPaths = [], signal, replyToMessageId) =>
-			sendDiscordMessage(account.botToken, conversation.channel.id, text, attachmentPaths, signal, replyToMessageId),
+		send: async (text, attachments = [], signal, replyToMessageId) =>
+			sendDiscordMessage(account.botToken, conversation.channel.id, text, attachments, signal, replyToMessageId),
 		startTyping: async () => {
 			const channel = await resolveTextChannel(client, conversation);
 			await channel.sendTyping();

--- a/src/live/telegram.ts
+++ b/src/live/telegram.ts
@@ -3,13 +3,7 @@ import type { InboundMessageInput } from "../core/runtime-types.js";
 import { chunkText } from "../render/chunking.js";
 import { formatMarkdownForService, maxMessageLength } from "../render/format.js";
 import { StreamingPreview } from "../render/streaming.js";
-import {
-	fetchBinary,
-	guessAttachmentKind,
-	readLocalAttachment,
-	storeDownloadedAttachment,
-	textMentionsBot,
-} from "./common.js";
+import { fetchBinary, guessAttachmentKind, storeDownloadedAttachment, textMentionsBot } from "./common.js";
 import type { LiveConnection, LiveConnectionHandlers, ResumeState } from "./types.js";
 
 interface TelegramResponse<T> {
@@ -326,10 +320,10 @@ export async function connectTelegramLive(
 					})
 				).message_id,
 			),
-		send: async (text, attachmentPaths = [], signal, replyToMessageId) => {
+		send: async (text, attachments = [], signal, replyToMessageId) => {
 			const rendered = formatMarkdownForService("telegram", text);
 			const replyParam = replyToMessageId ? { reply_to_message_id: Number(replyToMessageId) } : {};
-			if (attachmentPaths.length === 0) {
+			if (attachments.length === 0) {
 				const chunks = chunkText(rendered.text, maxMessageLength("telegram"));
 				let firstId: string | undefined;
 				for (let i = 0; i < chunks.length; i++) {
@@ -352,8 +346,7 @@ export async function connectTelegramLive(
 				}
 				return firstId || "";
 			}
-			const [firstPath, ...rest] = attachmentPaths;
-			const first = await readLocalAttachment(firstPath);
+			const [first, ...rest] = attachments;
 			const firstKind = guessAttachmentKind(first.name, first.mimeType);
 			const firstMethod = firstKind === "image" ? "sendPhoto" : "sendDocument";
 			const firstField = firstKind === "image" ? "photo" : "document";
@@ -371,8 +364,7 @@ export async function connectTelegramLive(
 			const firstData = (await firstResponse.json()) as TelegramResponse<{ message_id: number }>;
 			if (!firstResponse.ok || !firstData.ok || firstData.result === undefined)
 				throw new Error(firstData.description || `${firstMethod} failed`);
-			for (const path of rest) {
-				const file = await readLocalAttachment(path);
+			for (const file of rest) {
 				const kind = guessAttachmentKind(file.name, file.mimeType);
 				const method = kind === "image" ? "sendPhoto" : "sendDocument";
 				const field = kind === "image" ? "photo" : "document";

--- a/src/live/types.ts
+++ b/src/live/types.ts
@@ -1,5 +1,5 @@
 import type { ResolvedConversation } from "../core/config-types.js";
-import type { InboundMessageInput } from "../core/runtime-types.js";
+import type { InboundMessageInput, OutboundAttachment } from "../core/runtime-types.js";
 
 export interface LiveConnectionHandlers {
 	onMessage(input: InboundMessageInput, checkpoint?: { cursor?: string; messageId?: string }): Promise<void>;
@@ -19,7 +19,7 @@ export interface LiveConnection {
 	sendImmediate(text: string, replyToMessageId?: string): Promise<string | undefined>;
 	send(
 		text: string,
-		attachmentPaths?: string[],
+		attachments?: OutboundAttachment[],
 		signal?: AbortSignal,
 		replyToMessageId?: string,
 	): Promise<string | undefined>;


### PR DESCRIPTION
currently the host code needs to read from the guest file system when sending attachments and when reading skills, memory, etc.

it's doing a lot of checks to ensure that it's not reading files outside of the guest file system due to path traversal or symlinks.

this refactor changes the host to use the dedicated vm.fs functions which do these checks internally.

noteworthy changes in functionality:
- chat_attach can attach files outside of /workspace or /shared but is still limited to the guest vm filesystem.
- attachment contents are held in memory while they are queued which can add memory pressure. could be refactored so they are staged and later read one by one, or give the LiveConnection a way to read via vm.fs

feedback is welcome